### PR TITLE
레시피 상세보기를 변경하라

### DIFF
--- a/client/src/api/bookmark.ts
+++ b/client/src/api/bookmark.ts
@@ -9,10 +9,15 @@ import {
 	deleteDoc,
 } from "firebase/firestore";
 
-export const createBookmark = async (user: string, menu: string) => {
+import type { RecipeListData, BookmarkBoxProps } from "@/types/api.types";
+
+export const createBookmark = async (user: string, recipe: RecipeListData) => {
 	addDoc(collection(db, "bookmark"), {
 		user: user,
-		menu: menu,
+		menu: recipe.menuName,
+		count: recipe.ingredients.name.length,
+		ingredients: recipe.ingredients.name.join(", "),
+		image: recipe.menuImage,
 	});
 };
 
@@ -21,11 +26,18 @@ export const getBookmark = async (user: string) => {
 		query(collection(db, "bookmark"), where("user", "==", user)),
 	);
 
-	const data = response.docs.map((bookmark) => {
-		return bookmark.data();
+	const bookmark: BookmarkBoxProps[] = response.docs.map((bookmark) => {
+		const data = bookmark.data();
+		return {
+			user: data.user,
+			menu: data.menu,
+			count: data.count,
+			ingredients: data.ingredients,
+			image: data.image,
+		};
 	});
 
-	return data;
+	return bookmark;
 };
 
 export const getBookmarkid = async (user: string, menu: string) => {

--- a/client/src/api/recipe.ts
+++ b/client/src/api/recipe.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import recipeFilter from "@/utils/recipeFilter";
 
-export const getRecipe = async (food: string) => {
+export const getRecipeList = async (food: string) => {
 	const KEY = import.meta.env.VITE_API_RECIPE_KEY;
 
 	try {
@@ -20,7 +20,7 @@ export const getRecipe = async (food: string) => {
 	}
 };
 
-export const getBookmarkRecipe = async (menu: string) => {
+export const getRecipe = async (menu: string) => {
 	const KEY = import.meta.env.VITE_API_RECIPE_KEY;
 
 	try {

--- a/client/src/components/BookmarkBox/index.tsx
+++ b/client/src/components/BookmarkBox/index.tsx
@@ -1,55 +1,37 @@
 import styled from "styled-components";
 import Image from "../Image";
-import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { useUserSelectRecipeStore } from "@/store";
 import { FONT_SIZE } from "@/styles/common";
-import { getBookmarkRecipe } from "@/api/recipe";
 
-import type { RecipeListData } from "@/types/api.types";
+import type { BookmarkBoxProps } from "@/types/api.types";
 
-const BookmarkBox = ({ menu }: { menu: string }) => {
-	const { userSelectRecipe } = useUserSelectRecipeStore();
+const BookmarkBox = ({ recipe }: { recipe: BookmarkBoxProps }) => {
 	const navigate = useNavigate();
 
-	const { data: Recipe } = useQuery({
-		queryKey: ["bookmark", menu],
-		queryFn: async () => {
-			return await getBookmarkRecipe(menu);
-		},
-		staleTime: Infinity,
-		gcTime: Infinity,
-	});
-
-	const onClick = (recipe: RecipeListData) => {
-		userSelectRecipe(recipe);
-		navigate(`/recipe/detail`);
+	const onClick = () => {
+		navigate(`/recipe/detail/${recipe.menu}`);
 	};
 
 	return (
-		<>
-			{Recipe?.map((recipe) => (
-				<ResultBox onClick={() => onClick(recipe)}>
-					<SearchResultBoxInfoCard>
-						<Image
-							menu={recipe.menuName}
-							menuImage={recipe.menuImage}
-							width="198px"
-							height="150px"
-						/>
-						<InfoSection>
-							<InfoTopSection>
-								<Menu>{recipe.menuName}</Menu>
-							</InfoTopSection>
-							<IngredientsCount>
-								{recipe.ingredients.name.length}개 재료
-							</IngredientsCount>
-							<Ingredients>{recipe.ingredients.name.join(", ")}</Ingredients>
-						</InfoSection>
-					</SearchResultBoxInfoCard>
-				</ResultBox>
-			))}
-		</>
+		<ResultBox onClick={onClick}>
+			<SearchResultBoxInfoCard>
+				<Image
+					menu={recipe.menu}
+					menuImage={recipe.image}
+					width="198px"
+					height="150px"
+				/>
+				<InfoSection>
+					<InfoTopSection>
+						<Menu>{recipe.menu}</Menu>
+					</InfoTopSection>
+					<IngredientsCount>
+						{recipe.ingredients.length}개 재료
+					</IngredientsCount>
+					<Ingredients>{recipe.ingredients}</Ingredients>
+				</InfoSection>
+			</SearchResultBoxInfoCard>
+		</ResultBox>
 	);
 };
 

--- a/client/src/components/Image/index.tsx
+++ b/client/src/components/Image/index.tsx
@@ -4,8 +4,8 @@ import { BORDER_RADIUS } from "@/styles/common";
 interface ImageSectionProps {
 	width?: string;
 	height?: string;
-	minWidth?: string;
-	minHight?: string;
+	$minWidth?: string;
+	$minHeight?: string;
 }
 
 const ImageSection = styled.section<ImageSectionProps>`
@@ -13,10 +13,10 @@ const ImageSection = styled.section<ImageSectionProps>`
 	overflow: hidden;
 
 	width: ${({ width }) => width};
-	min-width: ${({ minWidth }) => minWidth};
+	min-width: ${({ $minWidth }) => $minWidth};
 
 	height: ${({ height }) => height};
-	min-height: ${({ minHight }) => minHight};
+	min-height: ${({ $minHeight }) => $minHeight};
 
 	border-radius: ${BORDER_RADIUS.md};
 `;
@@ -41,15 +41,15 @@ const Image = ({
 	menuImage,
 	width = "100%",
 	height = "100%",
-	minWidth = "150px",
-	minHight = "150px",
+	$minWidth = "150px",
+	$minHeight = "150px",
 }: ImageProps) => {
 	return (
 		<ImageSection
 			width={width}
 			height={height}
-			minWidth={minWidth}
-			minHight={minHight}
+			$minWidth={$minWidth}
+			$minHeight={$minHeight}
 		>
 			<ImageView src={menuImage} alt={menu} />
 		</ImageSection>

--- a/client/src/components/SearchResultBox/index.tsx
+++ b/client/src/components/SearchResultBox/index.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import Image from "../Image";
 import { useNavigate } from "react-router-dom";
-import { useUserSelectRecipeStore } from "@/store";
 import { FONT_SIZE } from "@/styles/common";
 import type { RecipeListData } from "@/types/api.types";
 
@@ -10,11 +9,9 @@ interface SearchResultBoxProps {
 }
 
 const SearchResultBox = ({ recipe }: SearchResultBoxProps) => {
-	const { userSelectRecipe } = useUserSelectRecipeStore();
 	const navigate = useNavigate();
 	const onClick = () => {
-		userSelectRecipe(recipe);
-		navigate(`/recipe/detail`);
+		navigate(`/recipe/detail/${recipe.menuName}`);
 	};
 
 	return (

--- a/client/src/constants/path.ts
+++ b/client/src/constants/path.ts
@@ -2,6 +2,6 @@ export const PATH = {
 	app: "/",
 	main: "/main",
 	recipeSearch: "/recipe/search/:foodCart",
-	recipeDetail: "/recipe/detail",
+	recipeDetail: "/recipe/detail/:menu",
 	bookmark: "/bookmark",
 } as const;

--- a/client/src/pages/BookmarkPage/index.tsx
+++ b/client/src/pages/BookmarkPage/index.tsx
@@ -16,13 +16,11 @@ const BookmarkPage = () => {
 		},
 	});
 
-	const menus = BookmarkList?.map((x) => x.menu);
-
 	return (
 		<Container>
 			<Banner>
 				<StyledLink to="/main">
-					<Title>&lt; &nbsp; 찜한 목록</Title>
+					<Title>{"< "}찜한 목록</Title>
 				</StyledLink>
 			</Banner>
 			<ResultSection>
@@ -30,7 +28,9 @@ const BookmarkPage = () => {
 				{BookmarkList && (
 					<>
 						<ResultCount>{BookmarkList.length}개의 레시피</ResultCount>
-						{menus?.map((menu) => <BookmarkBox menu={menu} />)}
+						{BookmarkList?.map((bookmark, index) => (
+							<BookmarkBox key={index} recipe={bookmark} />
+						))}
 					</>
 				)}
 			</ResultSection>

--- a/client/src/pages/RecipeDetailPage/index.tsx
+++ b/client/src/pages/RecipeDetailPage/index.tsx
@@ -1,39 +1,53 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useQuery } from "@tanstack/react-query";
 import { FONT_SIZE } from "@/styles/common";
 import Image from "@/components/Image";
 import RecipeInfo from "@/components/RecipeInfo";
-import { useUserSelectRecipeStore } from "@/store";
+import { useParams } from "react-router-dom";
 import TextButton from "@/components/TextButton";
 import { useLoginUser } from "@/store";
 import { createBookmark, deleteBookmark, getBookmark } from "@/api/bookmark";
+import { getRecipe } from "@/api/recipe";
 
 const RecipeDetailPage = () => {
-	const { selectedRecipe } = useUserSelectRecipeStore();
+	const { menu } = useParams();
 	const { loginUser } = useLoginUser();
-	const { menuName, menuImage } = selectedRecipe;
-	const [isBookmark, setIsBookmark] = useState<boolean>(false);
+	const [isBookmark, setIsBookmark] = useState(false);
+
+	const { data: Recipe } = useQuery({
+		queryKey: ["bookmark", menu],
+		queryFn: async () => {
+			const recipe = await getRecipe(menu!); // Page parameter라서 없을 수가 없음
+			if (recipe) {
+				return recipe[0];
+			}
+		},
+		staleTime: Infinity,
+		gcTime: Infinity,
+	});
 
 	const { data: BookmarkList } = useQuery({
 		queryKey: ["bookmark", loginUser],
-		queryFn: () => {
-			return getBookmark(loginUser!);
+		queryFn: async () => {
+			return await getBookmark(loginUser!);
 		},
 	});
 
-	const menus = BookmarkList?.map((x) => x.menu).includes(menuName);
-	if (menus) {
-		setIsBookmark(true);
-	}
+	useEffect(() => {
+		if (BookmarkList) {
+			const menus = BookmarkList?.map((x) => x.menu).includes(menu!);
+			setIsBookmark(menus);
+		}
+	}, [BookmarkList]);
 
 	const handleBookMark = () => {
 		if (isBookmark) {
-			deleteBookmark(loginUser!, menuName);
+			deleteBookmark(loginUser!, menu!);
 			alert("삭제되었습니다.");
 			setIsBookmark(false);
 		} else {
-			createBookmark(loginUser!, menuName);
+			createBookmark(loginUser!, Recipe!);
 			alert("추가되었습니다.");
 			setIsBookmark(true);
 		}
@@ -41,26 +55,29 @@ const RecipeDetailPage = () => {
 
 	return (
 		<Wrapper>
-			<Title>{menuName}</Title>
-			<Container>
-				<Section>
-					<Image
-						menu={menuName}
-						menuImage={menuImage}
-						width="500px"
-						height="450px"
-					/>
-					<TextButton
-						text={isBookmark ? "찜 삭제" : "찜 하기"}
-						colorType="dark"
-						type="button"
-						onClick={handleBookMark}
-					/>
-				</Section>
-				<DetailInfo>
-					<RecipeInfo recipe={selectedRecipe} />
-				</DetailInfo>
-			</Container>
+			<Title>{menu}</Title>
+			{!Recipe && <Container>레시피 불러오는 중..</Container>}
+			{Recipe && (
+				<Container>
+					<Section>
+						<Image
+							menu={Recipe.menuName}
+							menuImage={Recipe.menuImage}
+							width="500px"
+							height="450px"
+						/>
+						<TextButton
+							text={isBookmark ? "찜 삭제" : "찜 하기"}
+							colorType="dark"
+							type="button"
+							onClick={handleBookMark}
+						/>
+					</Section>
+					<DetailInfo>
+						<RecipeInfo recipe={Recipe} />
+					</DetailInfo>
+				</Container>
+			)}
 		</Wrapper>
 	);
 };

--- a/client/src/pages/RecipeSearchPage/index.tsx
+++ b/client/src/pages/RecipeSearchPage/index.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
 import { FONT_SIZE } from "@/styles/common";
-import { getRecipe } from "@/api/recipe";
+import { getRecipeList } from "@/api/recipe";
 import SearchResultBox from "@/components/SearchResultBox";
 
 const RecipeSearchPage = () => {
@@ -11,7 +11,7 @@ const RecipeSearchPage = () => {
 	const { data: RecipeList, isLoading } = useQuery({
 		queryKey: ["recipe", foodCart],
 		queryFn: () => {
-			return getRecipe(foodCart!); // Page parameter라서 없을 수가 없음
+			return getRecipeList(foodCart!); // Page parameter라서 없을 수가 없음
 		},
 		staleTime: Infinity,
 		gcTime: Infinity,

--- a/client/src/store/index.tsx
+++ b/client/src/store/index.tsx
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { CategoryData, RecipeListData } from "@/types/api.types";
+import type { CategoryData } from "@/types/api.types";
 
 interface UseLoginUserTyper {
 	loginUser: string | null;
@@ -70,25 +70,3 @@ export const useUserFoodCartStore = create<UserFoodCartStoreTyper>((set) => ({
 		})),
 	foodCartReset: () => set({ foodCart: [] }),
 }));
-
-interface UserSelectRecipeStoreType {
-	selectedRecipe: RecipeListData;
-	userSelectRecipe: (recipe: RecipeListData) => void;
-}
-
-export const useUserSelectRecipeStore = create<UserSelectRecipeStoreType>(
-	(set) => ({
-		selectedRecipe: {
-			id: "",
-			menuName: "",
-			menuImage: "",
-			ingredients: {
-				name: [],
-				detail: [],
-			},
-			recipeInfo: [],
-			menuTip: [],
-		},
-		userSelectRecipe: (recipe) => set({ selectedRecipe: recipe }),
-	}),
-);

--- a/client/src/types/api.types.ts
+++ b/client/src/types/api.types.ts
@@ -26,3 +26,11 @@ export interface RecipeListData {
 	recipeInfo: string[];
 	menuTip: string[];
 }
+
+export interface BookmarkBoxProps {
+	user: string;
+	menu: string;
+	count: number;
+	ingredients: string;
+	image: string;
+}


### PR DESCRIPTION
레시피 상세보기 변경 이유

1) 기존에는 유저가 선택한 레시피 정보를 전역 상태 관리에 가지고 있게 했다.
하지만 새로고침시 가지고 있는 레시피 정보가 날라가기 때문에 params로 레시피 명을 받고 api 요청을 다시해서 정보를 가져오는 식으로 수정이 필요하다. (이 부분은 당연한 건데 왜 생각을 못했을까..)

2) 찜한 목록을 불러올 때 기존에는 유저, 메뉴만 저장해서 유저가 저장한 메뉴를 한 번씩 돌아가며 API 요청하도록 했다.
하지만 너무 짧은 시간내에 여러개의 정보를 요청해서 에러가 발생했다.
그래서 찜하기 누를 당시에 유저, 메뉴, 재료, 이미지링크 를 가지고 있고 목록에서는 가지고 있는 정보만 보여주다가 클릭해서 레시피 상세보기로 넘어갔을 때만 API 요청하도록 변경했다.